### PR TITLE
WIP: Big mess of rework to filters.

### DIFF
--- a/config.json-sample
+++ b/config.json-sample
@@ -26,6 +26,35 @@
                 "alliance_loss": [99005065]
             },
             "webhook": "a_hook_url"
+        },
+        {
+            "type": "slack",
+            "subscribes_to": "kill",
+            "filter": {
+                "require_all_of": {
+                    "location": ["chain"]
+                },
+                "exclude_if_any": {
+                    "alliance_loss": [99999999],
+                    "location": [30000142, 30002187]
+                }
+            },
+            "webhook": "a_hook_url"
+        },
+        {
+            "type": "slack",
+            "subscribes_to": "kill",
+            "filter": {
+                "require_all_of": {
+                    "alliance_kill": [99999999],
+                    "minimum_value": [500e6]
+                },
+                "exclude_if_any": {
+                    "alliance_loss": [99999999]
+                }
+            },
+            "webhook": "a_hook_url"
         }
+
     ]
 }

--- a/tests/test_kill.py
+++ b/tests/test_kill.py
@@ -11,15 +11,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_alliance_no_matches(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"alliance_id": 2},
-            "attackers": [{"alliance_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"alliance_id": 2},
+                "attackers": [{"alliance_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_alliance([1], killmail, universe)
+                unchaind_kills._filter_alliance([1], package, universe)
             ),
             True,
         )
@@ -27,15 +29,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_alliance_victim_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"alliance_id": 1},
-            "attackers": [{"alliance_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"alliance_id": 1},
+                "attackers": [{"alliance_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_alliance([1], killmail, universe)
+                unchaind_kills._filter_alliance([1], package, universe)
             ),
             True,
         )
@@ -43,15 +47,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_alliance_attacker_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"alliance_id": 2},
-            "attackers": [{"alliance_id": 1}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"alliance_id": 2},
+                "attackers": [{"alliance_id": 1}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_alliance([1], killmail, universe)
+                unchaind_kills._filter_alliance([1], package, universe)
             ),
             False,
         )
@@ -59,15 +65,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_alliance_kill_no_matches(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"alliance_id": 2},
-            "attackers": [{"alliance_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"alliance_id": 2},
+                "attackers": [{"alliance_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_alliance_kill([1], killmail, universe)
+                unchaind_kills._filter_alliance_kill([1], package, universe)
             ),
             True,
         )
@@ -75,15 +83,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_alliance_kill_victim_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"alliance_id": 1},
-            "attackers": [{"alliance_id": 1234}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"alliance_id": 1},
+                "attackers": [{"alliance_id": 1234}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_alliance_kill([1], killmail, universe)
+                unchaind_kills._filter_alliance_kill([1], package, universe)
             ),
             True,
         )
@@ -91,15 +101,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_alliance_kill_attacker_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"alliance_id": 2},
-            "attackers": [{"alliance_id": 1}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"alliance_id": 2},
+                "attackers": [{"alliance_id": 1}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_alliance_kill([1], killmail, universe)
+                unchaind_kills._filter_alliance_kill([1], package, universe)
             ),
             False,
         )
@@ -107,15 +119,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_alliance_loss_no_matches(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"alliance_id": 2},
-            "attackers": [{"alliance_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"alliance_id": 2},
+                "attackers": [{"alliance_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_alliance_loss([1], killmail, universe)
+                unchaind_kills._filter_alliance_loss([1], package, universe)
             ),
             True,
         )
@@ -123,15 +137,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_alliance_loss_victim_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"alliance_id": 1},
-            "attackers": [{"alliance_id": 1234}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"alliance_id": 1},
+                "attackers": [{"alliance_id": 1234}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_alliance_loss([1], killmail, universe)
+                unchaind_kills._filter_alliance_loss([1], package, universe)
             ),
             False,
         )
@@ -139,15 +155,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_alliance_loss_attacker_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"alliance_id": 2},
-            "attackers": [{"alliance_id": 1}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"alliance_id": 2},
+                "attackers": [{"alliance_id": 1}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_alliance_loss([1], killmail, universe)
+                unchaind_kills._filter_alliance_loss([1], package, universe)
             ),
             True,
         )
@@ -155,15 +173,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_corporation_no_matches(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"corporation_id": 2},
-            "attackers": [{"corporation_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"corporation_id": 2},
+                "attackers": [{"corporation_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_corporation([1], killmail, universe)
+                unchaind_kills._filter_corporation([1], package, universe)
             ),
             True,
         )
@@ -171,15 +191,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_corporation_victim_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"corporation_id": 1},
-            "attackers": [{"corporation_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"corporation_id": 1},
+                "attackers": [{"corporation_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_corporation([1], killmail, universe)
+                unchaind_kills._filter_corporation([1], package, universe)
             ),
             True,
         )
@@ -187,15 +209,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_corporation_attacker_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"corporation_id": 2},
-            "attackers": [{"corporation_id": 1}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"corporation_id": 2},
+                "attackers": [{"corporation_id": 1}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_corporation([1], killmail, universe)
+                unchaind_kills._filter_corporation([1], package, universe)
             ),
             False,
         )
@@ -203,15 +227,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_corporation_kill_no_matches(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"corporation_id": 2},
-            "attackers": [{"corporation_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"corporation_id": 2},
+                "attackers": [{"corporation_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_corporation_kill([1], killmail, universe)
+                unchaind_kills._filter_corporation_kill([1], package, universe)
             ),
             True,
         )
@@ -219,15 +245,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_corporation_kill_victim_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"corporation_id": 1},
-            "attackers": [{"corporation_id": 1234}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"corporation_id": 1},
+                "attackers": [{"corporation_id": 1234}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_corporation_kill([1], killmail, universe)
+                unchaind_kills._filter_corporation_kill([1], package, universe)
             ),
             True,
         )
@@ -235,15 +263,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_corporation_kill_attacker_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"corporation_id": 2},
-            "attackers": [{"corporation_id": 1}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"corporation_id": 2},
+                "attackers": [{"corporation_id": 1}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_corporation_kill([1], killmail, universe)
+                unchaind_kills._filter_corporation_kill([1], package, universe)
             ),
             False,
         )
@@ -251,15 +281,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_corporation_loss_no_matches(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"corporation_id": 2},
-            "attackers": [{"corporation_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"corporation_id": 2},
+                "attackers": [{"corporation_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_corporation_loss([1], killmail, universe)
+                unchaind_kills._filter_corporation_loss([1], package, universe)
             ),
             True,
         )
@@ -267,15 +299,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_corporation_loss_victim_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"corporation_id": 1},
-            "attackers": [{"corporation_id": 1234}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"corporation_id": 1},
+                "attackers": [{"corporation_id": 1234}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_corporation_loss([1], killmail, universe)
+                unchaind_kills._filter_corporation_loss([1], package, universe)
             ),
             False,
         )
@@ -283,15 +317,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_corporation_loss_attacker_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"corporation_id": 2},
-            "attackers": [{"corporation_id": 1}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"corporation_id": 2},
+                "attackers": [{"corporation_id": 1}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_corporation_loss([1], killmail, universe)
+                unchaind_kills._filter_corporation_loss([1], package, universe)
             ),
             True,
         )
@@ -299,15 +335,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_character_no_matches(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"character_id": 2},
-            "attackers": [{"character_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"character_id": 2},
+                "attackers": [{"character_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_character([1], killmail, universe)
+                unchaind_kills._filter_character([1], package, universe)
             ),
             True,
         )
@@ -315,15 +353,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_character_victim_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"character_id": 1},
-            "attackers": [{"character_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"character_id": 1},
+                "attackers": [{"character_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_character([1], killmail, universe)
+                unchaind_kills._filter_character([1], package, universe)
             ),
             True,
         )
@@ -331,15 +371,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_character_attacker_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"character_id": 2},
-            "attackers": [{"character_id": 1}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"character_id": 2},
+                "attackers": [{"character_id": 1}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_character([1], killmail, universe)
+                unchaind_kills._filter_character([1], package, universe)
             ),
             False,
         )
@@ -347,15 +389,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_character_kill_no_matches(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"character_id": 2},
-            "attackers": [{"character_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"character_id": 2},
+                "attackers": [{"character_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_character_kill([1], killmail, universe)
+                unchaind_kills._filter_character_kill([1], package, universe)
             ),
             True,
         )
@@ -363,15 +407,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_character_kill_victim_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"character_id": 1},
-            "attackers": [{"character_id": 1234}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"character_id": 1},
+                "attackers": [{"character_id": 1234}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_character_kill([1], killmail, universe)
+                unchaind_kills._filter_character_kill([1], package, universe)
             ),
             True,
         )
@@ -379,15 +425,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_character_kill_attacker_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"character_id": 2},
-            "attackers": [{"character_id": 1}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"character_id": 2},
+                "attackers": [{"character_id": 1}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_character_kill([1], killmail, universe)
+                unchaind_kills._filter_character_kill([1], package, universe)
             ),
             False,
         )
@@ -395,15 +443,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_character_loss_no_matches(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"character_id": 2},
-            "attackers": [{"character_id": 2}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"character_id": 2},
+                "attackers": [{"character_id": 2}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_character_loss([1], killmail, universe)
+                unchaind_kills._filter_character_loss([1], package, universe)
             ),
             True,
         )
@@ -411,15 +461,17 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_character_loss_victim_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"character_id": 1},
-            "attackers": [{"character_id": 1234}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"character_id": 1},
+                "attackers": [{"character_id": 1234}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_character_loss([1], killmail, universe)
+                unchaind_kills._filter_character_loss([1], package, universe)
             ),
             False,
         )
@@ -427,15 +479,59 @@ class NotifierKillTest(unittest.TestCase):
     def test__filter_character_loss_attacker_match(self) -> None:
         universe = unchaind_universe.Universe.from_empty()
 
-        killmail = {
-            "killmail_id": 1,
-            "victim": {"character_id": 2},
-            "attackers": [{"character_id": 1}],
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"character_id": 2},
+                "attackers": [{"character_id": 1}],
+            }
         }
 
         self.assertEqual(
             loop.run_until_complete(
-                unchaind_kills._filter_character_loss([1], killmail, universe)
+                unchaind_kills._filter_character_loss([1], package, universe)
             ),
             True,
+        )
+
+    def test__filter_minimum_value_no_match(self) -> None:
+        universe = unchaind_universe.Universe.from_empty()
+
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"character_id": 2},
+                "attackers": [{"character_id": 1}],
+            },
+            "zkb": {
+                "totalValue": 999999.99
+            }
+        }
+
+        self.assertEqual(
+            loop.run_until_complete(
+                unchaind_kills._filter_minimum_value([1e6], package, universe)
+            ),
+            True
+        )
+
+    def test__filter_minimum_value_match(self) -> None:
+        universe = unchaind_universe.Universe.from_empty()
+
+        package = {
+            "killmail": {
+                "killmail_id": 1,
+                "victim": {"character_id": 2},
+                "attackers": [{"character_id": 1}],
+            },
+            "zkb": {
+                "totalValue": 999999.99
+            }
+        }
+
+        self.assertEqual(
+            loop.run_until_complete(
+                unchaind_kills._filter_minimum_value([1e5], package, universe)
+            ),
+            False
         )

--- a/unchaind/command.py
+++ b/unchaind/command.py
@@ -104,6 +104,8 @@ class Command:
 
             loop: ioloop.IOLoop = ioloop.IOLoop.current()
             loop.add_callback(self.loop_kills)
+        else:
+            app_log().warning("Did not find any notifiers subscribed to kills")
 
     async def periodic_mappers(self, init: bool = True) -> None:
         """Run all of our mappers periodically."""

--- a/unchaind/kills.py
+++ b/unchaind/kills.py
@@ -8,7 +8,7 @@ from asyncio import gather
 
 from unchaind.http import HTTPSession
 from unchaind.universe import System, Universe
-from unchaind.notify import types
+from unchaind.notify import sinks
 from unchaind.util import system_name
 from unchaind.log import app_log
 
@@ -37,6 +37,7 @@ async def loop(config: Dict[str, Any], universe: Universe) -> None:
     package = data.get("package", None)
 
     if not package:
+        app_log().debug("empty reply from zkb")
         return
 
     try:
@@ -45,18 +46,23 @@ async def loop(config: Dict[str, Any], universe: Universe) -> None:
         app_log().warning("Received unparseable killmail from zkillboard")
         return
 
+    kill_id = killmail["killmail_id"]
+    message = f"https://zkillboard.com/kill/{kill_id}/"
+
     # Find any matching notifiers
-    matches = await match_killmail(config, universe, killmail)
+    matches = await match_killmail(config, universe, package)
 
     if not matches:
+        app_log().debug(f"no matches for {kill_id}")
         return
 
-    await gather(*[types[match["type"]](match, killmail) for match in matches])
+    await gather(*[sinks[match["type"]](match, message) for match in matches])
 
 
 async def _filter_location(
-    values: List[str], killmail: Dict[str, Any], universe: Universe
+    values: List[Any], package: Dict[str, Any], universe: Universe
 ) -> bool:
+    killmail = package["killmail"]
     solar_system = System(killmail.get("solar_system_id", None))
 
     if "chain" in values:
@@ -81,21 +87,30 @@ async def _filter_location(
                 killmail["killmail_id"],
             )
 
+    if solar_system.identifier in values:
+        app_log().debug(
+            "Killmail %s: found %s in %s",
+            killmail["killmail_id"],
+            str(solar_system),
+            repr(values),
+        )
+        return False
+
     return True
 
 
 async def _filter_alliance(
-    values: List[int], killmail: Dict[str, Any], universe: Universe
+    values: List[int], package: Dict[str, Any], universe: Universe
 ) -> bool:
     """For the alliance filter the victim or any of the attackers have to be
        in the list of alliances."""
 
-    loss = await _filter_alliance_kill(values, killmail, universe)
+    loss = await _filter_alliance_kill(values, package, universe)
 
     if not loss:
         return False
 
-    kill = await _filter_alliance_kill(values, killmail, universe)
+    kill = await _filter_alliance_kill(values, package, universe)
 
     if not kill:
         return False
@@ -104,10 +119,12 @@ async def _filter_alliance(
 
 
 async def _filter_alliance_kill(
-    values: List[int], killmail: Dict[str, Any], universe: Universe
+    values: List[int], package: Dict[str, Any], universe: Universe
 ) -> bool:
     """For the alliance filter the victim or any of the attackers have to be
        in the list of alliances."""
+
+    killmail = package["killmail"]
 
     attackers = killmail.get("attackers", [])
 
@@ -125,10 +142,12 @@ async def _filter_alliance_kill(
 
 
 async def _filter_alliance_loss(
-    values: List[int], killmail: Dict[str, Any], universe: Universe
+    values: List[int], package: Dict[str, Any], universe: Universe
 ) -> bool:
     """For the alliance filter the victim or any of the attackers have to be
        in the list of alliances."""
+
+    killmail = package["killmail"]
 
     victim = killmail.get("victim", {})
 
@@ -148,17 +167,17 @@ async def _filter_alliance_loss(
 
 
 async def _filter_corporation(
-    values: List[int], killmail: Dict[str, Any], universe: Universe
+    values: List[int], package: Dict[str, Any], universe: Universe
 ) -> bool:
     """For the corporation filter the victim or any of the attackers have to be
        in the list of corporations."""
 
-    loss = await _filter_corporation_kill(values, killmail, universe)
+    loss = await _filter_corporation_kill(values, package, universe)
 
     if not loss:
         return False
 
-    kill = await _filter_corporation_kill(values, killmail, universe)
+    kill = await _filter_corporation_kill(values, package, universe)
 
     if not kill:
         return False
@@ -167,10 +186,12 @@ async def _filter_corporation(
 
 
 async def _filter_corporation_kill(
-    values: List[int], killmail: Dict[str, Any], universe: Universe
+    values: List[int], package: Dict[str, Any], universe: Universe
 ) -> bool:
     """For the corporation filter the victim or any of the attackers have to be
        in the list of corporations."""
+
+    killmail = package["killmail"]
 
     attackers = killmail.get("attackers", [])
 
@@ -188,10 +209,12 @@ async def _filter_corporation_kill(
 
 
 async def _filter_corporation_loss(
-    values: List[int], killmail: Dict[str, Any], universe: Universe
+    values: List[int], package: Dict[str, Any], universe: Universe
 ) -> bool:
     """For the corporation filter the victim or any of the attackers have to be
        in the list of corporations."""
+
+    killmail = package["killmail"]
 
     victim = killmail.get("victim", {})
 
@@ -209,17 +232,17 @@ async def _filter_corporation_loss(
 
 
 async def _filter_character(
-    values: List[int], killmail: Dict[str, Any], universe: Universe
+    values: List[int], package: Dict[str, Any], universe: Universe
 ) -> bool:
     """For the character filter the victim or any of the attackers have to be
        in the list of characters."""
 
-    loss = await _filter_character_kill(values, killmail, universe)
+    loss = await _filter_character_kill(values, package, universe)
 
     if not loss:
         return False
 
-    kill = await _filter_character_kill(values, killmail, universe)
+    kill = await _filter_character_kill(values, package, universe)
 
     if not kill:
         return False
@@ -228,10 +251,12 @@ async def _filter_character(
 
 
 async def _filter_character_kill(
-    values: List[int], killmail: Dict[str, Any], universe: Universe
+    values: List[int], package: Dict[str, Any], universe: Universe
 ) -> bool:
     """For the character filter the victim or any of the attackers have to be
        in the list of characters."""
+
+    killmail = package["killmail"]
 
     attackers = killmail.get("attackers", [])
 
@@ -249,10 +274,12 @@ async def _filter_character_kill(
 
 
 async def _filter_character_loss(
-    values: List[int], killmail: Dict[str, Any], universe: Universe
+    values: List[int], package: Dict[str, Any], universe: Universe
 ) -> bool:
     """For the character filter the victim or any of the attackers have to be
        in the list of characters."""
+
+    killmail = package["killmail"]
 
     victim = killmail.get("victim", {})
 
@@ -269,6 +296,26 @@ async def _filter_character_loss(
     return True
 
 
+async def _filter_minimum_value(
+    values: List[int], package: Dict[str, Any], universe: Universe
+) -> bool:
+    """Filter kills that are not of at least a minimum value."""
+
+    kill_value = package["zkb"]["totalValue"]
+    minimum = values[0]
+
+    rv = minimum > kill_value
+    if rv:
+        app_log().debug(
+            "Killmail %s was filtered due to value less than threshold (%s < %s)",
+            package["killmail"]["killmail_id"],
+            kill_value,
+            minimum,
+        )
+
+    return bool(minimum > kill_value)
+
+
 # I gave up on trying to type this properly...
 filters: Dict[str, Any] = {
     "location": _filter_location,
@@ -281,11 +328,12 @@ filters: Dict[str, Any] = {
     "corporation_loss": _filter_corporation_loss,
     "character_kill": _filter_character_kill,
     "character_loss": _filter_character_loss,
+    "minimum_value": _filter_minimum_value,
 }
 
 
 async def match_killmail(
-    config: Dict[str, Any], universe: Universe, killmail: Dict[str, Any]
+    config: Dict[str, Any], universe: Universe, package: Dict[str, Any]
 ) -> List[Dict[str, Any]]:
 
     """Filter a killmail with its set of notifier filters. Returns the notifier
@@ -301,14 +349,27 @@ async def match_killmail(
         # This reads a bit difficult but this checks if all filters for this
         # notifier were False. If they were then that notifier would like to
         # receive this kill!
-        results = await gather(
+        require_all_of_results = await gather(
             *[
-                filters[name](values, killmail, universe)
-                for name, values in notifier["filter"].items()
+                filters[name](values, package, universe)
+                for name, values in notifier["filter"]
+                .get("require_all_of", {})
+                .items()
             ]
         )
 
-        if not all(results):
+        exclude_if_any_results = await gather(
+            *[
+                filters[name](values, package, universe)
+                for name, values in notifier["filter"]
+                .get("exclude_if_any", {})
+                .items()
+            ]
+        )
+
+        # XXX invert the boolean senses of filters, this is horrifying and could be
+        # so much easier to read and reason about.
+        if (not any(require_all_of_results)) and all(exclude_if_any_results):
             matches.append(notifier)
 
     return matches

--- a/unchaind/notify.py
+++ b/unchaind/notify.py
@@ -5,15 +5,12 @@ import json
 from typing import Dict, Any
 
 from unchaind.http import HTTPSession
+from unchaind.log import app_log
 
 
-async def discord(notifier: Dict[str, Any], killmail: Dict[str, Any]) -> None:
-    """Send a discord message to the configured channel."""
+async def discord(notifier: Dict[str, Any], message: str) -> None:
+    """Send a Discord message to the configured channel."""
     http = HTTPSession()
-
-    kill_id = killmail["killmail_id"]
-
-    message = f"https://zkillboard.com/kill/{kill_id}/"
 
     await http.request(
         url=notifier["webhook"],
@@ -22,4 +19,20 @@ async def discord(notifier: Dict[str, Any], killmail: Dict[str, Any]) -> None:
     )
 
 
-types = {"discord": discord}
+async def console(notifier: Dict[str, Any], message: str) -> None:
+    """Log a message.  Intended for debugging use."""
+    app_log().info("NOTIFICATION: " + message)
+
+
+async def slack(notifier: Dict[str, Any], message: str) -> None:
+    """Send a Slack message to the configured channel."""
+    http = HTTPSession()
+
+    await http.request(
+        url=notifier["webhook"],
+        method="POST",
+        body=json.dumps({"text": message}),
+    )
+
+
+sinks = {"discord": discord, "console": console, "slack": slack}


### PR DESCRIPTION
This is not ready to go in!  But it's such a big revamp that I want feedback before
I polish it much more.

Also happy to split this up into multiple pulls

* Slack notifier.
* Notifiers now receive strings instead of just a killmail ID.

* A few extra logging messages
* Rename notifiers.types to notifiers.sinks (types is such an overloaded name)

* Filters now operate on the entire 'package' rather than just the  'killmail' sub-section.  Needed for:
* minimum_value filter which reads package['zkb']['totalValue']

* 'exclude_if_any' inverts the usual sense of filters: we'll skip a killmail if it matches one of the filters in this area.  Useful to prevent the bot from posting about your own losses, or about kills happening 'in chain' that are happening in Jita/Amarr which perhaps are pinned to your Siggy.

* Filters working as before are now in 'require_all_of'.
  Perhaps this name is confusing and could be better?
  Or perhaps we can fix it by making the filter names a bit better -- e.g. "location_is_in" or "location_one_of"

I want to change the idea of filters (returns True if we should 'skip' a mail)
into the notion of matchers (returns True if a mail matches a given property)
just because that's much easier to reason about, especially given the new
require/exclude distinction.

I also want to change the set of filters away from being a dict into being
a list of dicts, so you can do e.g.
```
                "require_all_of": [
                    {"location": ["chain"]},
                    {"location": ["wspace"]}
                ]
```