### PR TITLE
wrap entire zkb fetch in a generic Exception handler

### DIFF
--- a/unchaind/notifier/kill.py
+++ b/unchaind/notifier/kill.py
@@ -20,9 +20,15 @@ async def loop(config: Dict[str, Any], universe: Universe) -> None:
 
     http = HTTPSession()
 
-    response = await http.request(
-        url="https://redisq.zkillboard.com/listen.php", method="GET"
-    )
+    try:
+        response = await http.request(
+            url="https://redisq.zkillboard.com/listen.php", method="GET"
+        )
+    except Exception as err:
+        log.warning(
+            "loop: zkillboard fetch threw exception %s", err, exc_info=err
+        )
+        return
 
     if response.code != 200:
         log.warning("loop: received response code %s", response.code)


### PR DESCRIPTION
this has proven necessary as there are several different exceptions
that occur only rarely -- not just HTTPTimeoutError but also
ConnectionRefusedError, OSError, socket.gaierror... I do not believe
this list to be exhaustive.